### PR TITLE
.vscode added to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ coverage
 # Vercel
 .vercel
 
+# VS Code
+.vscode
+
 # Build Outputs
 .next/
 out/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-  "eslint.workingDirectories": [
-    {
-      "mode": "auto"
-    }
-  ]
-}


### PR DESCRIPTION
# Why
`.vscode` should probably not be in our repo since individual developers might have their own specific configs for the project :)
# What
- Added the `.vscode` pattern to the `.gitignore` file
- Removed the folder + `.vscode/settings.json` file from the repo to get rid of the folder completely
# Satisfies
Issue #2 